### PR TITLE
Make project deployable to AppEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Make sure you have golang installed
 
 ## Deploying to appengine
 1. Install [Cloud SDK](https://cloud.google.com/sdk/docs/install)
-2. Obtain credentials: `gcloud auth login`
-3. Set default project: `gcloud config set project go-whiteboard`
-4. Verify settings (account, project): `gcloud config list`
-5. To deploy the project cd into the folder with app.yaml and then `gcloud app
+2. Install AppEngine extension for Go: `gcloud components install app-engine-go`
+3. Obtain credentials: `gcloud auth login`
+4. Set default project: `gcloud config set project go-whiteboard`
+5. Verify settings (account, project): `gcloud config list`
+6. To deploy the project cd into the folder with app.yaml and then `gcloud app
 deploy`
+7. To verify deployed project:
+`curl https://go-whiteboard.appspot.com/helloWorld`

--- a/src/.gcloudignore
+++ b/src/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+# Test binary, build with `go test -c`
+*.test
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/src/app.yaml
+++ b/src/app.yaml
@@ -1,0 +1,1 @@
+runtime: go116

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,3 +1,3 @@
 module whiteboard
 
-go 1.17
+go 1.16

--- a/src/main.go
+++ b/src/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"log"
 	"net/http"
-	"whiteboard/src/handler"
+	"os"
+	"whiteboard/handler"
 )
 
 func main() {
 	http.HandleFunc("/helloWorld", handler.HelloWorld)
-	http.ListenAndServe(":5000", nil)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+	http.ListenAndServe(":"+port, nil)
 }


### PR DESCRIPTION
In this PR:
- Add app.yaml with AppEngine runtime configuration
- Read port from AppEngine environment. Fallback to 8080